### PR TITLE
fixed dag miscount, added history

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -129,13 +129,15 @@ function predict(history) {
     const points = history.map(x=>{const date = Date.parse(x.date); return [parseInt(x.uncomplete),date]})
     if (points.length <3) {return ""}
     const r = new regression("linear",points.reverse())
-    const zeroPoint = r.equation[1]
 
-    // if zero point is in the past then we are in trouble!
-    if (zeroPoint < points[0][1] || isNaN(zeroPoint)) {
+    // the slope of the result has to be negative otherwise it means
+    // we'll never finish
+    if (r.string.startsWith("y = -")) {
+        const zeroPoint = r.equation[1]
+        return dateStr(new Date(zeroPoint))
+    } else {
         return "NEVER!";
     }
-    return dateStr(new Date(zeroPoint))
 }
 
 function isToday(date_str) {

--- a/public/rtb.html
+++ b/public/rtb.html
@@ -3,5 +3,6 @@
 <head>
     <script type="text/javascript" src="https://realtimeboard.com/app/static/rtb.sdk.1.1.js"></script>
     <script type="text/javascript" src="main.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/regression/1.4.0/regression.min.js"></script>
 </head>
 </html>

--- a/simpleserver.js
+++ b/simpleserver.js
@@ -98,5 +98,5 @@ app.post('/update-soa-tree-data', function (req, res) {
 })
 
 app.listen(process.env.PORT || 8088, function () {
-  console.log('CORS-enabled web server listening on port ' + (process.env.PORT || 80))
+  console.log('CORS-enabled web server listening on port ' + (process.env.PORT || 8088))
 })

--- a/simpleserver.js
+++ b/simpleserver.js
@@ -97,6 +97,6 @@ app.post('/update-soa-tree-data', function (req, res) {
   res.sendStatus(200)
 })
 
-app.listen(process.env.PORT || 80, function () {
+app.listen(process.env.PORT || 8088, function () {
   console.log('CORS-enabled web server listening on port ' + (process.env.PORT || 80))
 })


### PR DESCRIPTION
This PR fixes the problem of miscounts when the tree is a DAG instead of a strict tree, by recursively building up the list of types of nodes as a hash and returning the node ids instead of the counts.  That way they don't get double counted.

Also, adds history to time (teal) nodes and calculates a linear regression on that history to make a prediction about when the number of incomplete smalls goes to 0.